### PR TITLE
Fixed NPE on devices without billing service

### DIFF
--- a/Donations/src/main/java/org/sufficientlysecure/donations/google/util/IabHelper.java
+++ b/Donations/src/main/java/org/sufficientlysecure/donations/google/util/IabHelper.java
@@ -265,7 +265,8 @@ public class IabHelper {
 
         Intent serviceIntent = new Intent("com.android.vending.billing.InAppBillingService.BIND");
         serviceIntent.setPackage("com.android.vending");
-        if (!mContext.getPackageManager().queryIntentServices(serviceIntent, 0).isEmpty()) {
+        List<ResolveInfo> queriedIntentServices = mContext.getPackageManager().queryIntentServices(serviceIntent, 0);
+        if (queriedIntentServices != null && !queriedIntentServices.isEmpty()) {
             // service available to handle that Intent
             mContext.bindService(serviceIntent, mServiceConn, Context.BIND_AUTO_CREATE);
         }


### PR DESCRIPTION
Especially when testing on emulators the method queryIntentServices() can and will return null, causing the fragment to crash onActivityCreated.